### PR TITLE
Update GUI to include "Tutees" header

### DIFF
--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -5,7 +5,7 @@
 
 .list-cell:empty {
     /* Empty cells will not have alternating colours */
-    -fx-background: #383838;
+    -fx-background: #243042;
 }
 
 .tag-selector {

--- a/src/main/resources/view/HelpWindow.css
+++ b/src/main/resources/view/HelpWindow.css
@@ -1,3 +1,3 @@
 #copyButton, #helpMessage {
-    -fx-font-family: "Open Sans";
+    -fx-font-family: "SF UI Display Medium";
 }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -3,6 +3,7 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
@@ -10,6 +11,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Font?>
 <?import javafx.stage.Stage?>
 
 <fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Track-O" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1">
@@ -36,16 +38,53 @@
           <padding>
             <Insets bottom="10" left="10" right="10" top="10" />
           </padding>
+               <HBox minWidth="340.0" prefHeight="40.0" prefWidth="340.0">
+                  <children>
+                     <StackPane fx:id="personListPanelPlaceholder1" alignment="CENTER_LEFT" centerShape="false" prefHeight="40.0" prefWidth="158.0" HBox.hgrow="ALWAYS">
+                        <children>
+                           <Label styleClass="window-headers" text="Tutees" textFill="WHITE">
+                              <font>
+                                 <Font name="System Bold" size="14.0" />
+                              </font>
+                           </Label>
+                        </children>
+                        <padding>
+                           <Insets left="10.0" />
+                        </padding>
+                     </StackPane>
+                     <StackPane fx:id="resultDisplayPlaceholder1" alignment="CENTER_RIGHT" centerShape="false" prefHeight="40.0" prefWidth="158.0" HBox.hgrow="ALWAYS">
+                        <children>
+                           <Label styleClass="window-headers" textFill="WHITE" StackPane.alignment="CENTER_LEFT">
+                              <font>
+                                 <Font name="System Bold" size="14.0" />
+                              </font>
+                              <padding>
+                                 <Insets left="5.0" />
+                              </padding>
+                           </Label>
+                        </children>
+                        <padding>
+                           <Insets left="10.0" />
+                        </padding>
+                     </StackPane>
+                  </children>
+               </HBox>
                <HBox minWidth="340.0" prefHeight="506.0" prefWidth="340.0" VBox.vgrow="ALWAYS">
                   <children>
                 <StackPane fx:id="personListPanelPlaceholder" alignment="CENTER_LEFT" centerShape="false" prefHeight="200.0" prefWidth="158.0" HBox.hgrow="ALWAYS" />
-                          <StackPane fx:id="resultDisplayPlaceholder" alignment="CENTER_RIGHT" centerShape="false" prefHeight="200.0" prefWidth="158.0" styleClass="pane-with-border" HBox.hgrow="ALWAYS" />
+                          <StackPane fx:id="resultDisplayPlaceholder" alignment="CENTER_RIGHT" centerShape="false" prefHeight="200.0" prefWidth="158.0" styleClass="pane-without-border" HBox.hgrow="ALWAYS" />
                   </children>
+                  <opaqueInsets>
+                     <Insets />
+                  </opaqueInsets>
                </HBox>
-                          <StackPane fx:id="commandBoxPlaceholder" alignment="CENTER_LEFT" prefHeight="12.0" prefWidth="147.0" styleClass="pane-with-border" VBox.vgrow="NEVER">
-             <padding>
-               <Insets bottom="5" left="10" right="10" top="5" />
-             </padding>
+                          <StackPane fx:id="commandBoxPlaceholder" alignment="CENTER_LEFT" prefHeight="12.0" prefWidth="147.0" styleClass="pane-without-border" VBox.vgrow="NEVER">
+                  <opaqueInsets>
+                     <Insets />
+                  </opaqueInsets>
+                  <padding>
+                     <Insets top="20.0" />
+                  </padding>
            </StackPane>
         </VBox>
         <StackPane fx:id="statusbarPlaceholder" prefWidth="260.0" VBox.vgrow="NEVER" />

--- a/src/main/resources/view/NewTheme.css
+++ b/src/main/resources/view/NewTheme.css
@@ -142,6 +142,11 @@
      -fx-border-top-width: 1px;
 }
 
+.pane-without-border {
+    -fx-background-color: derive(#243040, 20%);
+}
+
+
 .status-bar {
     -fx-background-color: derive(#3977d5, 30%);
 }
@@ -198,7 +203,7 @@
 
 .menu-bar .label {
     -fx-font-size: 14pt;
-    -fx-font-family: "SF UI DisplayLight";
+    -fx-font-family: "SF UI Display Semibold";
     -fx-text-fill: white;
     -fx-opacity: 0.9;
 }
@@ -307,6 +312,13 @@
     -fx-padding: 8 1 8 1;
 }
 
+.window-headers {
+    -fx-background-color: transparent;
+    -fx-font-family: "SF UI Display Semibold";
+    -fx-font-size: 16pt;
+    -fx-text-fill: white;
+}
+
 #cardPane {
     -fx-background-color: transparent;
     -fx-border-width: 0;
@@ -350,3 +362,5 @@
     -fx-background-radius: 2;
     -fx-font-size: 11;
 }
+
+

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -3,6 +3,6 @@
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.StackPane?>
 
-<StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane fx:id="placeHolder" styleClass="pane-without-border" xmlns="http://javafx.com/javafx/null" xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" prefHeight="60.0" prefWidth="512.0" styleClass="result-display" wrapText="true" />
 </StackPane>


### PR DESCRIPTION
Let's update the GUI to include a header for "Tutees" to indicate to users where to find their tutees

Before:
![image](https://user-images.githubusercontent.com/44387213/136797905-e0dad5e8-cc22-494a-908f-36358758ec82.png)

After:
![image](https://user-images.githubusercontent.com/44387213/136797189-c36fa11e-3254-4fd7-b663-31e5ab921700.png)
