### PR TITLE
Update UG for add, edit and clear

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -288,7 +288,7 @@ _Details coming soon ..._
 
 Action | Format, Examples
 --------|------------------
-**Add** | `add n/NAME p/PHONE sch/SCHOOL l/LEVEL a/ADDRESS [t/TAG]…` <br> e.g. `add n/James Ho p/87652345 sch/Anderson sec l/S4 a/200 Yio Chu Kang Road`
+**Add** | `add n/NAME p/PHONE sch/SCHOOL l/LEVEL a/ADDRESS [t/TAG]…` <br> e.g. `add n/James Ho p/87652345 sch/Anderson sec l/s4 a/200 Yio Chu Kang Road`
 **Edit** | `edit INDEX [n/NAME] [p/PHONE] [sch/SCHOOL] [l/LEVEL] [a/ADDRESS] [t/TAG]…` <br> e.g. `edit 2 sch/Victoria Jc l/j1`
 **Delete** | `delete INDEX`<br> e.g. `delete 3`
 **Get** | `get INDEX`<br> e.g. `get 2`


### PR DESCRIPTION
- Added missing prefixes, such as `p/`, `sch/`, `a/`, `t/` to add command and edit command.
- Added a simple explanation of what `clear` does.
- Replaced the command examples that involve `l/` with lowercase `p`, `s` and `j`.