### PR TITLE
Update Payment error message

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -279,7 +279,10 @@ public class ParserUtil {
         requireNonNull(paymentValue);
         String trimmedPayment = paymentValue.trim();
         if (!Payment.isValidPayment(trimmedPayment)) {
-            throw new ParseException(Payment.MESSAGE_CONSTRAINTS);
+            if (!Payment.isPaymentWithAnyDecimals(trimmedPayment)) {
+                throw new ParseException(Payment.MESSAGE_CONSTRAINTS);
+            }
+            throw new ParseException(Payment.DECIMAL_CONSTRAINTS);
         }
         return trimmedPayment;
     }

--- a/src/main/java/seedu/address/model/tutee/Payment.java
+++ b/src/main/java/seedu/address/model/tutee/Payment.java
@@ -17,15 +17,19 @@ import java.util.List;
 public class Payment {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Payment values should only contain numbers, and it should be at least 1 digit long.";
+            "Payment values should only contain positive numbers with at least 1 digit, allowing 0 or 2 decimals i.e"
+                    + "100 or 74.50";
+    public static final String DECIMAL_CONSTRAINTS =
+            "Payment values must have either 0 or 2 decimal places and end with either a 0 or 5, i.e 40.50 or 40.55.";
     public static final String DATE_CONSTRAINTS =
             "Payment due dates should be in the format of dd-MM-yyyy, i.e 20-10-2021 and must equal to or after"
                     + " today's date.";
     public static final String PAYMENT_HISTORY_CONSTRAINTS =
             "Payment history should only contain dates in the format of dd-MM-yyyy, i.e 20-10-2021, and 'Never'.";
-
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd-MM-yyyy");
     public static final String TODAY_DATE_AS_STRING = LocalDate.now().format(FORMATTER);
+    public static final String VALIDATION_REGEX_NUMERICAL_FRONT_ANY_DECIMALS = "^[0-9][\\d]*([.][0-9]+)?$"
+            .replaceFirst("^0+", "");
     public static final String VALIDATION_REGEX_PAYMENT_NO_OR_TWO_DECIMAL_PLACES = "^[0-9][\\d]*([.][0-9][0|5])?$"
             .replaceFirst("^0+", "");
     public final String value;
@@ -60,9 +64,22 @@ public class Payment {
 
     /**
      * Returns true if a given string is a valid payment amount.
+     * @param test The string to test on
+     * @return Whether the string matches the regex
      */
     public static boolean isValidPayment(String test) {
         return test.matches(VALIDATION_REGEX_PAYMENT_NO_OR_TWO_DECIMAL_PLACES);
+    }
+
+
+    /**
+     * Returns true if a given string is a payment amount with any number of decimal places,
+     * which may or may not be valid.
+     * @param test The string to test on
+     * @return Whether the string matches the regex
+     */
+    public static boolean isPaymentWithAnyDecimals(String test) {
+        return test.matches(VALIDATION_REGEX_NUMERICAL_FRONT_ANY_DECIMALS);
     }
 
     /**

--- a/src/main/java/seedu/address/model/tutee/Payment.java
+++ b/src/main/java/seedu/address/model/tutee/Payment.java
@@ -18,7 +18,7 @@ public class Payment {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Payment values should only contain positive numbers with at least 1 digit, allowing 0 or 2 decimals i.e"
-                    + "100 or 74.50";
+                    + " 100 or 74.50";
     public static final String DECIMAL_CONSTRAINTS =
             "Payment values must have either 0 or 2 decimal places and end with either a 0 or 5, i.e 40.50 or 40.55.";
     public static final String DATE_CONSTRAINTS =

--- a/src/test/java/seedu/address/model/tutee/PaymentTest.java
+++ b/src/test/java/seedu/address/model/tutee/PaymentTest.java
@@ -48,6 +48,31 @@ public class PaymentTest {
     }
 
     @Test
+    public void isPaymentWithAnyDecimalsTest() {
+        // null payment
+        assertThrows(NullPointerException.class, () -> Payment.isPaymentWithAnyDecimals(null));
+
+        // invalid payment amounts
+        assertFalse(Payment.isPaymentWithAnyDecimals("")); // empty string
+        assertFalse(Payment.isPaymentWithAnyDecimals(" ")); // spaces only
+        assertFalse(Payment.isPaymentWithAnyDecimals("-91")); // // non-numeric
+        assertFalse(Payment.isPaymentWithAnyDecimals("9011p041")); // alphabets within digits
+        assertFalse(Payment.isPaymentWithAnyDecimals("9312 1534")); // spaces within digits
+        assertFalse(Payment.isPaymentWithAnyDecimals("90.")); // decimal point with no decimal value
+
+
+        // valid payment amounts
+        assertTrue(Payment.isPaymentWithAnyDecimals("90.33")); // any number for decimal places allowed
+        assertTrue(Payment.isPaymentWithAnyDecimals("90.333")); // any number of decimals allowed
+        assertTrue(Payment.isPaymentWithAnyDecimals("90.123456789")); // any number of decimals allowed
+        assertTrue(Payment.isPaymentWithAnyDecimals("911"));
+        assertTrue(Payment.isPaymentWithAnyDecimals("93121534"));
+        assertTrue(Payment.isPaymentWithAnyDecimals("124293842033123"));
+        assertTrue(Payment.isPaymentWithAnyDecimals("90.50"));
+        assertTrue(Payment.isPaymentWithAnyDecimals("90.00"));
+    }
+
+    @Test
     public void isValidPayByDate() {
         assertThrows(NullPointerException.class, () -> Payment.isValidPayByDate(null));
 


### PR DESCRIPTION
Resolves #133 #143 #150 #151 

#133, #150 and #151 noted that error message feedback given was not accurate for the given input.

Let's add a new error message to distinguish between incorrect inputs.
Fix:
![image](https://user-images.githubusercontent.com/44387213/139666200-5baa43e5-79ac-4705-844c-9b7f7d1b5da7.png)

#143 noted that negative numbers were not allowed, and the error message now reads:
Let's add a more descriptive error message for incorrect inputs:
`Payment values should only contain positive numbers with at least 1 digit, allowing 0 or 2 decimals i.e 100 or 74.50`