### PR TITLE
Fix error messages for payment class and refactored code

### DIFF
--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentAddCommand.java
@@ -29,8 +29,6 @@ public class PaymentAddCommand extends PaymentCommand {
             + "LESSON_INDEX (must be a positive integer)\n"
             + "Example: payment 1 " + PREFIX_LESSON + "1\n\n";
 
-    public static final String UPDATE_TUTEE_PAYMENT_SUCCESS = "Updated Payment details of %s:\n%s";
-
     public static final String MESSAGE_LESSON_INDEX_OUT_OF_BOUNDS = "Lesson index provided is invalid.";
 
     private final Index targetIndex;
@@ -56,7 +54,7 @@ public class PaymentAddCommand extends PaymentCommand {
      * @return New payment value owed by tutee
      * @throws CommandException If an error occurs during command execution.
      */
-    private String addLessonCostToValue(Index lessonIndex, Tutee tutee) throws CommandException {
+    public static String addLessonCostToValue(Index lessonIndex, Tutee tutee) throws CommandException {
 
         Payment existingPayment = tutee.getPayment();
         String existingPaymentValue = existingPayment.getValue();
@@ -100,7 +98,8 @@ public class PaymentAddCommand extends PaymentCommand {
 
         String updatedPaymentAsString = addLessonCostToValue(lessonIndex, tuteeToGet);
 
-        Tutee editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, updatedPaymentAsString, existingPayByDate);
+        Tutee editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, updatedPaymentAsString, existingPayByDate,
+                null);
 
         model.setTutee(tuteeToGet, editedTutee);
         model.updateFilteredTuteeList(PREDICATE_SHOW_ALL_TUTEES);

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentCommand.java
@@ -1,10 +1,6 @@
 package seedu.address.logic.commands.paymentcommand;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LESSON;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_AMOUNT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PAYMENT_RECEIVED_DATE;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -35,10 +31,20 @@ public class PaymentCommand extends Command {
 
     public static final String COMMAND_WORD = "payment";
 
+    // Default usage of payment allows you to view payment details of current tutee
     public static final String MESSAGE_DEFAULT_USAGE = COMMAND_WORD
             + ": View payment details of the tutee identified by the index number used in the displayed tutee list.\n"
             + "Required Parameters: TUTEE_INDEX (must be a positive integer)\n" + "Example: payment 1\n\n";
 
+    // Basic usage on the extensions for payment command
+    public static final String MESSAGE_BASIC_USAGE_ALL = PaymentAddCommand.BASIC_USAGE
+                    + PaymentSetAmountCommand.BASIC_USAGE
+                    + PaymentSetDateCommand.BASIC_USAGE
+                    + PaymentReceiveCommand.BASIC_USAGE
+                    + "\n"
+                    + "For more details on payment commands: payment";
+
+    // Elaborated usage on the extensions for payment command
     public static final String MESSAGE_USAGE_ALL = "Payment command has the following functionalities and"
             + " is to only include up to 1 parameter:\n\n"
             + MESSAGE_DEFAULT_USAGE
@@ -48,18 +54,13 @@ public class PaymentCommand extends Command {
             + PaymentReceiveCommand.MESSAGE_USAGE
             + "\n";
 
-    public static final String MESSAGE_PAYMENT_MANAGEMENT_USAGE =
-            COMMAND_WORD + " TUTEE_INDEX " + PREFIX_LESSON + "LESSON_INDEX\n"
-            + COMMAND_WORD + " TUTEE_INDEX " + PREFIX_PAYMENT_AMOUNT + "PAYMENT_AMOUNT\n"
-            + COMMAND_WORD + " TUTEE_INDEX " + PREFIX_PAYMENT_DATE + "PAYMENT_DATE\n"
-            + COMMAND_WORD + " TUTEE_INDEX " + PREFIX_PAYMENT_RECEIVED_DATE + "[DATE_RECEIVED]\n\n"
-            + "For more details on payment commands: payment";
-
+    // Separator to showcase basic extensions on payment command
     public static final String SEPARATOR_TITLE = "Command usages to manage the payment details of tutee:\n";
 
+    // Final payment details formatting including basic payment extension command usage
     public static final String MESSAGE_VIEW_TUTEE_PAYMENT_SUCCESS = "Payment details of %s:\n%s%s\n"
             + SEPARATOR_TITLE
-            + MESSAGE_PAYMENT_MANAGEMENT_USAGE;
+            + MESSAGE_BASIC_USAGE_ALL;
 
     private final Index targetIndex;
 
@@ -93,9 +94,7 @@ public class PaymentCommand extends Command {
         }
 
         Tutee tuteeToGet = lastShownList.get(targetIndex.getZeroBased());
-        List<Lesson> lessons = tuteeToGet.getLessons();
 
-        //Edit this portion to link payment details instead of tutee
         String tuteePaymentDetails = getPaymentDetailsMessage(tuteeToGet);
         return new CommandResult(tuteePaymentDetails);
     }
@@ -130,7 +129,8 @@ public class PaymentCommand extends Command {
     }
 
     /**
-     * Uses the information of an existing tutee and creates a new tutee with the updated payment details.
+     * Uses the information of an existing tutee and creates a new tutee with the updated payment details and
+     * updates the last paid date of tutee (when the receive command is used)
      *
      * @param tuteeToEdit Existing tutee
      * @param payment Payment amount to set

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentCommand.java
@@ -62,6 +62,8 @@ public class PaymentCommand extends Command {
             + SEPARATOR_TITLE
             + MESSAGE_BASIC_USAGE_ALL;
 
+    public static final String UPDATE_TUTEE_PAYMENT_SUCCESS = "Updated Payment details of %s:\n%s";
+
     private final Index targetIndex;
 
     public PaymentCommand(Index targetIndex) {
@@ -99,43 +101,15 @@ public class PaymentCommand extends Command {
         return new CommandResult(tuteePaymentDetails);
     }
 
-
-    /**
-     * Uses the information of an existing tutee and creates a new tutee with the updated payment details.
-     *
-     * @param tuteeToEdit Existing tutee
-     * @param payment Payment amount to set
-     * @param payByDate Date that tutee is to pay amount by
-     * @return A new tutee object with the updated payment details
-     */
-
-    public static Tutee createEditedPaymentDetailsTutee(Tutee tuteeToEdit, String payment, LocalDate payByDate) {
-        assert tuteeToEdit != null;
-
-        Name updatedName = tuteeToEdit.getName();
-        Phone updatedPhone = tuteeToEdit.getPhone();
-        School updatedSchool = tuteeToEdit.getSchool();
-        Level updatedLevel = tuteeToEdit.getLevel();
-        Address updatedAddress = tuteeToEdit.getAddress();
-        Payment existingPayment = tuteeToEdit.getPayment();
-        Payment updatedPayment = new Payment(payment, payByDate);
-        updatedPayment.copyPaymentHistory(existingPayment.paymentHistory);
-        Remark updatedRemark = tuteeToEdit.getRemark(); // edit command does not allow editing remarks
-        Set<Tag> updatedTags = tuteeToEdit.getTags();
-        List<Lesson> updatedLessons = tuteeToEdit.getLessons(); // edit command does not allow editing lessons
-
-        return new Tutee(updatedName, updatedPhone, updatedSchool, updatedLevel, updatedAddress,
-                updatedPayment, updatedRemark, updatedTags, updatedLessons);
-    }
-
     /**
      * Uses the information of an existing tutee and creates a new tutee with the updated payment details and
-     * updates the last paid date of tutee (when the receive command is used)
+     * updates the last paid date of tutee (only when the receive command is used). In cases where other commands are
+     * used, lastPaidDate will be null.
      *
      * @param tuteeToEdit Existing tutee
      * @param payment Payment amount to set
      * @param payByDate Date that tutee is to pay amount by
-     * @param lastPaidDate Date that tutee paid
+     * @param lastPaidDate Date that tutee paid, to be only initialized when receive command is used
      * @return
      */
     public static Tutee createEditedPaymentDetailsTutee(Tutee tuteeToEdit, String payment, LocalDate payByDate,
@@ -147,8 +121,14 @@ public class PaymentCommand extends Command {
         School updatedSchool = tuteeToEdit.getSchool();
         Level updatedLevel = tuteeToEdit.getLevel();
         Address updatedAddress = tuteeToEdit.getAddress();
+        Payment existingPayment = tuteeToEdit.getPayment();
         Payment updatedPayment = new Payment(payment, payByDate);
-        updatedPayment.paymentHistory.add(lastPaidDate);
+        if (lastPaidDate != null) {
+            updatedPayment.paymentHistory.add(lastPaidDate);
+        } else {
+            List<String> existingPaymentHist = existingPayment.paymentHistory;
+            updatedPayment.copyPaymentHistory(existingPaymentHist);
+        }
         Remark updatedRemark = tuteeToEdit.getRemark(); // edit command does not allow editing remarks
         Set<Tag> updatedTags = tuteeToEdit.getTags();
         List<Lesson> updatedLessons = tuteeToEdit.getLessons(); // edit command does not allow editing lessons

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentReceiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentReceiveCommand.java
@@ -80,20 +80,22 @@ public class PaymentReceiveCommand extends PaymentCommand {
         LocalDate existingPayByDate = existingPayment.getPayByDate();
         Tutee editedTutee;
 
-        if (ZERO_PAYMENT_VAL.equals(existingPaymentValue) && newPayByDate == null && existingPayByDate == null) {
-            throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE);
-        } else if (ZERO_PAYMENT_VAL.equals(existingPaymentValue) && newPayByDate == null) {
-            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL,
-                    NULL_PAY_BY_DATE, TODAY_DATE_AS_STRING);
-        } else if (ZERO_PAYMENT_VAL.equals(existingPaymentValue) && newPayByDate.equals(existingPayByDate)) {
-            throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE);
-        } else if (newPayByDate == null && existingPayByDate != null) {
-            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL,
-                    NULL_PAY_BY_DATE, TODAY_DATE_AS_STRING);
-        } else {
-            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL,
-                    newPayByDate, TODAY_DATE_AS_STRING);
+        boolean hasZeroPaymentValue = ZERO_PAYMENT_VAL.equals(existingPaymentValue);
+        boolean hasNullExistingDate = existingPayByDate == null;
+        boolean hasNullNewPayByDate = newPayByDate == null;
+        boolean hasSameExistingAndNewDate = false;
+
+        if (!hasNullNewPayByDate) {
+            hasSameExistingAndNewDate = newPayByDate.equals(existingPayByDate);
         }
+        // Case where current payment value is currently zero, existing date is not set, user input does not set date
+        if (hasZeroPaymentValue && hasNullNewPayByDate && hasNullExistingDate) {
+            throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE);
+        } else if (hasZeroPaymentValue && hasSameExistingAndNewDate) {
+            throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE);
+        }
+
+        editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL, newPayByDate, TODAY_DATE_AS_STRING);
 
         model.setTutee(tuteeToGet, editedTutee);
         model.updateFilteredTuteeList(PREDICATE_SHOW_ALL_TUTEES);

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentReceiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentReceiveCommand.java
@@ -31,14 +31,11 @@ public class PaymentReceiveCommand extends PaymentCommand {
             + "Optional Parameters: PAY_BY_DATE (in the format of dd-mm-yyyy)\n"
             + "Example: payment 1 " + PREFIX_PAYMENT_RECEIVED_DATE + "15-10-2021\n\n";
 
-    public static final String UPDATE_TUTEE_PAYMENT_SUCCESS = "Updated Payment details of %s:\n%s";
-
     public static final String MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE = "Current payment value owed by tutee "
             + "is already 0 and date to make payment by had no change.";
 
 
     private static final String ZERO_PAYMENT_VAL = "0";
-    private static final LocalDate NULL_PAY_BY_DATE = null;
 
 
     private final Index targetIndex;
@@ -78,7 +75,6 @@ public class PaymentReceiveCommand extends PaymentCommand {
         Payment existingPayment = tuteeToGet.getPayment();
         String existingPaymentValue = existingPayment.getValue();
         LocalDate existingPayByDate = existingPayment.getPayByDate();
-        Tutee editedTutee;
 
         boolean hasZeroPaymentValue = ZERO_PAYMENT_VAL.equals(existingPaymentValue);
         boolean hasNullExistingDate = existingPayByDate == null;
@@ -88,14 +84,15 @@ public class PaymentReceiveCommand extends PaymentCommand {
         if (!hasNullNewPayByDate) {
             hasSameExistingAndNewDate = newPayByDate.equals(existingPayByDate);
         }
-        // Case where current payment value is currently zero, existing date is not set, user input does not set date
+        // Cases where current payment value is currently zero and dates have no change
         if (hasZeroPaymentValue && hasNullNewPayByDate && hasNullExistingDate) {
             throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE);
         } else if (hasZeroPaymentValue && hasSameExistingAndNewDate) {
             throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE);
         }
 
-        editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL, newPayByDate, TODAY_DATE_AS_STRING);
+        Tutee editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL,
+                newPayByDate, TODAY_DATE_AS_STRING);
 
         model.setTutee(tuteeToGet, editedTutee);
         model.updateFilteredTuteeList(PREDICATE_SHOW_ALL_TUTEES);

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentReceiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentReceiveCommand.java
@@ -37,7 +37,6 @@ public class PaymentReceiveCommand extends PaymentCommand {
 
     private static final String ZERO_PAYMENT_VAL = "0";
 
-
     private final Index targetIndex;
     private final LocalDate newPayByDate;
 
@@ -76,7 +75,7 @@ public class PaymentReceiveCommand extends PaymentCommand {
         String existingPaymentValue = existingPayment.getValue();
         LocalDate existingPayByDate = existingPayment.getPayByDate();
 
-        boolean hasZeroPaymentValue = ZERO_PAYMENT_VAL.equals(existingPaymentValue);
+        boolean hasZeroPaymentValue = Double.parseDouble(existingPaymentValue) == 0;
         boolean hasNullExistingDate = existingPayByDate == null;
         boolean hasNullNewPayByDate = newPayByDate == null;
         boolean hasSameExistingAndNewDate = false;

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentReceiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentReceiveCommand.java
@@ -20,6 +20,9 @@ public class PaymentReceiveCommand extends PaymentCommand {
 
     public static final String COMMAND_WORD = "payment";
 
+    public static final String BASIC_USAGE = COMMAND_WORD + " TUTEE_INDEX "
+            + PREFIX_PAYMENT_RECEIVED_DATE + "[DATE_RECEIVED]\n";
+
     public static final String MESSAGE_USAGE = "Sets payment value owed by the tutee identified "
             + "by the index number used in the displayed tutee list to 0 and "
             + "has an optional date field to update the date to make next payment by. If no date is set, "
@@ -30,12 +33,16 @@ public class PaymentReceiveCommand extends PaymentCommand {
 
     public static final String UPDATE_TUTEE_PAYMENT_SUCCESS = "Updated Payment details of %s:\n%s";
 
-    public static final String MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE = "Payment value owed by tutee "
+    public static final String MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE = "Current payment value owed by tutee "
             + "is already 0 and date to make payment by had no change.";
+
+
+    private static final String ZERO_PAYMENT_VAL = "0";
+    private static final LocalDate NULL_PAY_BY_DATE = null;
+
+
     private final Index targetIndex;
     private final LocalDate newPayByDate;
-    private final String zeroPaymentVal = "0";
-    private final LocalDate nullPayByDate = null;
 
 
     /**
@@ -73,18 +80,18 @@ public class PaymentReceiveCommand extends PaymentCommand {
         LocalDate existingPayByDate = existingPayment.getPayByDate();
         Tutee editedTutee;
 
-        if (zeroPaymentVal.equals(existingPaymentValue) && newPayByDate == null && existingPayByDate == null) {
+        if (ZERO_PAYMENT_VAL.equals(existingPaymentValue) && newPayByDate == null && existingPayByDate == null) {
             throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE);
-        } else if (zeroPaymentVal.equals(existingPaymentValue) && newPayByDate == null) {
-            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, zeroPaymentVal,
-                    nullPayByDate, TODAY_DATE_AS_STRING);
-        } else if (zeroPaymentVal.equals(existingPaymentValue) && newPayByDate.equals(existingPayByDate)) {
+        } else if (ZERO_PAYMENT_VAL.equals(existingPaymentValue) && newPayByDate == null) {
+            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL,
+                    NULL_PAY_BY_DATE, TODAY_DATE_AS_STRING);
+        } else if (ZERO_PAYMENT_VAL.equals(existingPaymentValue) && newPayByDate.equals(existingPayByDate)) {
             throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE);
         } else if (newPayByDate == null && existingPayByDate != null) {
-            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, zeroPaymentVal,
-                    nullPayByDate, TODAY_DATE_AS_STRING);
+            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL,
+                    NULL_PAY_BY_DATE, TODAY_DATE_AS_STRING);
         } else {
-            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, zeroPaymentVal,
+            editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, ZERO_PAYMENT_VAL,
                     newPayByDate, TODAY_DATE_AS_STRING);
         }
 

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentSetAmountCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentSetAmountCommand.java
@@ -26,6 +26,9 @@ public class PaymentSetAmountCommand extends PaymentCommand {
 
     public static final String COMMAND_WORD = "payment";
 
+    public static final String BASIC_USAGE = COMMAND_WORD + " TUTEE_INDEX "
+            + PREFIX_PAYMENT_AMOUNT + "PAYMENT_AMOUNT\n";
+
     public static final String MESSAGE_USAGE = "Update payment value owed by the tutee identified "
             + "by the index number used in the displayed tutee list to new specified value.\n"
             + "Required Parameters: TUTEE_INDEX (must be a positive integer), "

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentSetAmountCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentSetAmountCommand.java
@@ -35,8 +35,6 @@ public class PaymentSetAmountCommand extends PaymentCommand {
             + "PAYMENT_VALUE (must be a positive value up to 2 decimal places)\n"
             + "Example: payment 1 " + PREFIX_PAYMENT_AMOUNT + "150\n\n";
 
-    public static final String UPDATE_TUTEE_PAYMENT_SUCCESS = "Updated Payment details of %s:\n%s";
-
     public static final String MESSAGE_NO_CHANGE_IN_PAYMENT_VALUE = "Payment value provided is the same"
             + " as the existing payment value of tutee.";
 
@@ -75,7 +73,7 @@ public class PaymentSetAmountCommand extends PaymentCommand {
         Payment existingPayment = tuteeToGet.getPayment();
         String existingPaymentValue = existingPayment.getValue();
         LocalDate existingPayByDate = existingPayment.getPayByDate();
-        Tutee editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, paymentValueToSet, existingPayByDate);
+        Tutee editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, paymentValueToSet, existingPayByDate, null);
 
         // If existing value is same as input value
         if (paymentValueToSet.equals(existingPaymentValue)) {

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentSetDateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentSetDateCommand.java
@@ -28,8 +28,6 @@ public class PaymentSetDateCommand extends PaymentCommand {
             + "PAY_BY_DATE (in the format of dd-mm-yyyy)\n"
             + "Example: payment 1 " + PREFIX_PAYMENT_DATE + "15-10-2021\n\n";
 
-    public static final String UPDATE_TUTEE_PAYMENT_SUCCESS = "Updated Payment details of %s:\n%s";
-
     public static final String MESSAGE_NO_CHANGE_IN_PAYMENT_DATE = "Payment date owed by tutee "
             + "is the same as existing payment date";
 
@@ -76,7 +74,7 @@ public class PaymentSetDateCommand extends PaymentCommand {
             throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_DATE);
         }
 
-        Tutee editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, existingPaymentValue, newPayByDate);
+        Tutee editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, existingPaymentValue, newPayByDate, null);
 
         model.setTutee(tuteeToGet, editedTutee);
         model.updateFilteredTuteeList(PREDICATE_SHOW_ALL_TUTEES);

--- a/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentSetDateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/paymentcommand/PaymentSetDateCommand.java
@@ -20,6 +20,8 @@ public class PaymentSetDateCommand extends PaymentCommand {
 
     public static final String COMMAND_WORD = "payment";
 
+    public static final String BASIC_USAGE = COMMAND_WORD + " TUTEE_INDEX " + PREFIX_PAYMENT_DATE + "PAYMENT_DATE\n";
+
     public static final String MESSAGE_USAGE = "Update the date to pay by for tutee identified "
             + "by the index number used in the displayed tutee list to new specified date.\n"
             + "Required Parameters: TUTEE_INDEX (must be a positive integer), "
@@ -68,14 +70,13 @@ public class PaymentSetDateCommand extends PaymentCommand {
         Payment existingPayment = tuteeToGet.getPayment();
         String existingPaymentValue = existingPayment.getValue();
         LocalDate existingPayByDate = existingPayment.getPayByDate();
-        Tutee editedTutee;
 
         // If existing pay by value is same as input date value
         if (newPayByDate.equals(existingPayByDate)) {
             throw new CommandException(MESSAGE_NO_CHANGE_IN_PAYMENT_DATE);
         }
 
-        editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, existingPaymentValue, newPayByDate);
+        Tutee editedTutee = createEditedPaymentDetailsTutee(tuteeToGet, existingPaymentValue, newPayByDate);
 
         model.setTutee(tuteeToGet, editedTutee);
         model.updateFilteredTuteeList(PREDICATE_SHOW_ALL_TUTEES);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -43,6 +43,7 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }

--- a/src/main/java/seedu/address/model/tutee/Payment.java
+++ b/src/main/java/seedu/address/model/tutee/Payment.java
@@ -126,7 +126,7 @@ public class Payment {
         } else if (payByDateAsString.equals("-")) {
             return "No (Pay-by date not set)";
         } else {
-            return "No (by " + payByDateAsString + ")";
+            return "No (Next payment date by: " + payByDateAsString + ")";
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteLessonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteLessonCommandTest.java
@@ -172,7 +172,7 @@ public class DeleteLessonCommandTest {
         }
     }
 
-    private static class LessonMock {
+    public static class LessonMock {
         public static Lesson getLesson() throws ParseException {
             Subject subject = ParserUtil.parseSubject(VALID_LESSON_SUBJECT_BOB);
             DayOfWeek dayOfWeek = ParserUtil.parseDayOfWeek(VALID_LESSON_DAY_OF_WEEK_BOB);

--- a/src/test/java/seedu/address/logic/commands/paymentcommandtest/PaymentAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/paymentcommandtest/PaymentAddCommandTest.java
@@ -3,11 +3,16 @@ package seedu.address.logic.commands.paymentcommandtest;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.paymentcommand.PaymentAddCommand.MESSAGE_LESSON_INDEX_OUT_OF_BOUNDS;
+import static seedu.address.logic.commands.paymentcommand.PaymentAddCommand.addLessonCostToValue;
+import static seedu.address.logic.commands.paymentcommand.PaymentCommand.UPDATE_TUTEE_PAYMENT_SUCCESS;
+import static seedu.address.logic.commands.paymentcommandtest.PaymentCommandTest.modifyPaymentOfTutee;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_LESSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TUTEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LESSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TUTEE;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_TUTEE;
 import static seedu.address.testutil.TypicalTutees.getTypicalTrackO;
 
 import java.time.LocalDate;
@@ -16,33 +21,23 @@ import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.paymentcommand.PaymentAddCommand;
-import seedu.address.logic.commands.paymentcommand.PaymentCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.exceptions.ScheduleClashException;
 import seedu.address.model.lesson.Lesson;
+import seedu.address.model.tutee.Payment;
 import seedu.address.model.tutee.Tutee;
 
 public class PaymentAddCommandTest {
 
-    private static final String NEW_PAYMENT_VAL_STUB_1 = "100";
-    private static final String NEW_PAYMENT_VAL_STUB_2 = "200";
     private Model model;
 
     public PaymentAddCommandTest() throws ScheduleClashException {
         this.model = new ModelManager(getTypicalTrackO(), new UserPrefs());
-    }
-
-    private Model modifyPaymentOfTutee(Index index, String newPaymentValue,
-                                       LocalDate newPayByDate) throws ScheduleClashException {
-        Model model = new ModelManager(getTypicalTrackO(), new UserPrefs());
-        Tutee retrievedTutee = model.getFilteredTuteeList().get(index.getZeroBased());
-        Tutee editedTutee = PaymentCommand.createEditedPaymentDetailsTutee(retrievedTutee, newPaymentValue,
-                newPayByDate);
-        model.setTutee(retrievedTutee, editedTutee);
-        return model;
     }
 
     @Test
@@ -84,23 +79,29 @@ public class PaymentAddCommandTest {
         assertFalse(getFirstCommand.equals(getSecondCommand));
     }
 
-    // To be completed once lesson cost calculation is finalized
-    /*@Test
-    public void execute_changeInPayment_success() throws CommandException {
+    @Test
+    public void execute_addLessonFees_success() throws CommandException, ScheduleClashException {
 
-        // Creates tutee with specified payment details
-        Tutee retrievedTutee = model.getFilteredTuteeList().get(INDEX_FIRST_TUTEE.getZeroBased());
+        model = new ModelManager(getTypicalTrackO(), new UserPrefs());
+        Tutee thirdTutee = model.getFilteredTuteeList().get(INDEX_THIRD_TUTEE.getZeroBased());
+        Index firstLessonIndex = Index.fromOneBased(1);
+
+        Tutee retrievedTutee = model.getFilteredTuteeList().get(INDEX_THIRD_TUTEE.getZeroBased());
         Payment retrievedTuteePayment = retrievedTutee.getPayment();
-        LocalDate payByDate = retrievedTuteePayment.getPayByDate();
-        model = modifyPaymentOfTutee(INDEX_FIRST_TUTEE, NEW_PAYMENT_VAL_STUB_1, payByDate);
+        LocalDate existingPayByDate = retrievedTuteePayment.getPayByDate();
 
-        PaymentAddCommand paymentAddCommand = new PaymentAddCommand(INDEX_FIRST_TUTEE,
-                NEW_PAYMENT_VAL_STUB_2);
+        PaymentAddCommand paymentAddCommand = new PaymentAddCommand(INDEX_THIRD_TUTEE,
+                firstLessonIndex);
 
-        paymentAddCommand.execute(model);
-        Tutee expectedTutee = PaymentCommand.editedPaymentDetailsTutee(retrievedTutee, NEW_PAYMENT_VAL_STUB_2,
-                payByDate);
-        Tutee actualTutee = model.getFilteredTuteeList().get(INDEX_FIRST_TUTEE.getZeroBased());
-        assertEquals(expectedTutee.getPayment(), actualTutee.getPayment());
-    }*/
+        String newPaymentVal = addLessonCostToValue(firstLessonIndex, thirdTutee);
+
+        Model expectedModel = modifyPaymentOfTutee(INDEX_THIRD_TUTEE, newPaymentVal, existingPayByDate, null);
+
+        String successMsg = String.format(UPDATE_TUTEE_PAYMENT_SUCCESS, retrievedTutee.getName(),
+                new Payment(newPaymentVal, existingPayByDate));
+
+        CommandResult expectedMsg = new CommandResult(successMsg);
+
+        assertCommandSuccess(paymentAddCommand, model, expectedMsg, expectedModel);
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/paymentcommandtest/PaymentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/paymentcommandtest/PaymentCommandTest.java
@@ -8,6 +8,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TUTEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TUTEE;
 import static seedu.address.testutil.TypicalTutees.getTypicalTrackO;
 
+import java.time.LocalDate;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
@@ -28,6 +30,17 @@ import seedu.address.model.tutee.Tutee;
 public class PaymentCommandTest {
 
     private Model model;
+
+
+    public static Model modifyPaymentOfTutee(Index index, String newPaymentValue,
+                                       LocalDate newPayByDate, String lastPaidDate) throws ScheduleClashException {
+        Model model = new ModelManager(getTypicalTrackO(), new UserPrefs());
+        Tutee retrievedTutee = model.getFilteredTuteeList().get(index.getZeroBased());
+        Tutee editedTutee = PaymentCommand.createEditedPaymentDetailsTutee(retrievedTutee, newPaymentValue,
+                newPayByDate, lastPaidDate);
+        model.setTutee(retrievedTutee, editedTutee);
+        return model;
+    }
 
     @Test
     public void execute_validIndexUnfilteredList_success() throws ScheduleClashException {

--- a/src/test/java/seedu/address/logic/commands/paymentcommandtest/PaymentSetDateTest.java
+++ b/src/test/java/seedu/address/logic/commands/paymentcommandtest/PaymentSetDateTest.java
@@ -1,10 +1,12 @@
 package seedu.address.logic.commands.paymentcommandtest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.paymentcommand.PaymentSetDateCommand.MESSAGE_NO_CHANGE_IN_PAYMENT_DATE;
+import static seedu.address.logic.commands.paymentcommand.PaymentSetDateCommand.UPDATE_TUTEE_PAYMENT_SUCCESS;
+import static seedu.address.logic.commands.paymentcommandtest.PaymentCommandTest.modifyPaymentOfTutee;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_TUTEE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_TUTEE;
 import static seedu.address.testutil.TypicalTutees.getTypicalTrackO;
@@ -15,8 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.commands.paymentcommand.PaymentCommand;
+import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.paymentcommand.PaymentSetDateCommand;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -38,16 +39,6 @@ public class PaymentSetDateTest {
     private static final LocalDate NULL_DATE = null;
 
     private Model model;
-
-    private Model modifyPaymentOfTutee(Index index, String newPaymentValue,
-                                       LocalDate newPayByDate) throws ScheduleClashException {
-        Model model = new ModelManager(getTypicalTrackO(), new UserPrefs());
-        Tutee retrievedTutee = model.getFilteredTuteeList().get(index.getZeroBased());
-        Tutee editedTutee = PaymentCommand.createEditedPaymentDetailsTutee(retrievedTutee, newPaymentValue,
-                newPayByDate);
-        model.setTutee(retrievedTutee, editedTutee);
-        return model;
-    }
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() throws ParseException,
@@ -88,6 +79,7 @@ public class PaymentSetDateTest {
         assertFalse(getFirstCommand.equals(getSecondCommand));
     }
 
+    // Input date is same as existing date
     @Test
     public void execute_noChangeInPaymentDate_throwsCommandException() throws ParseException, ScheduleClashException {
 
@@ -98,7 +90,7 @@ public class PaymentSetDateTest {
         String retrievedPaymentVal = retrievedTuteePayment.getValue();
         LocalDate payByDate = ParserUtil.parsePayByDate(NEW_PAYBYDATE_VAL_STUB_2);
 
-        model = modifyPaymentOfTutee(INDEX_FIRST_TUTEE, retrievedPaymentVal , payByDate);
+        model = modifyPaymentOfTutee(INDEX_FIRST_TUTEE, retrievedPaymentVal , payByDate, null);
 
         PaymentSetDateCommand paymentSetDateCommand = new PaymentSetDateCommand(INDEX_FIRST_TUTEE,
                 payByDate);
@@ -108,7 +100,7 @@ public class PaymentSetDateTest {
 
     // Tutee with null date to initialized date
     @Test
-    public void execute_changeInPaymentDate_success() throws CommandException, ParseException, ScheduleClashException {
+    public void execute_changeInPaymentDate_success() throws ParseException, ScheduleClashException {
 
         model = new ModelManager(getTypicalTrackO(), new UserPrefs());
         LocalDate newPayByDate2 = ParserUtil.parsePayByDate(NEW_PAYBYDATE_VAL_STUB_2);
@@ -117,22 +109,22 @@ public class PaymentSetDateTest {
         Payment retrievedTuteePayment = retrievedTutee.getPayment();
         String retrievedPaymentVal = retrievedTuteePayment.getValue();
 
-        model = modifyPaymentOfTutee(INDEX_FIRST_TUTEE, retrievedPaymentVal, NULL_DATE);
-
+        model = modifyPaymentOfTutee(INDEX_FIRST_TUTEE, retrievedPaymentVal, NULL_DATE, null);
+        Model expectedModel = modifyPaymentOfTutee(INDEX_FIRST_TUTEE, retrievedPaymentVal, newPayByDate2, null);
         PaymentSetDateCommand paymentSetDateCommand = new PaymentSetDateCommand(INDEX_FIRST_TUTEE,
                 newPayByDate2);
 
-        paymentSetDateCommand.execute(model);
-        Tutee expectedTutee = PaymentCommand.createEditedPaymentDetailsTutee(retrievedTutee, retrievedPaymentVal,
-                newPayByDate2);
-        Tutee actualTutee = model.getFilteredTuteeList().get(INDEX_FIRST_TUTEE.getZeroBased());
-        assertEquals(expectedTutee.getPayment(), actualTutee.getPayment());
+        String successMsg = String.format(UPDATE_TUTEE_PAYMENT_SUCCESS, retrievedTutee.getName(),
+                new Payment(retrievedPaymentVal, newPayByDate2));
+
+        CommandResult expectedMsg = new CommandResult(successMsg);
+
+        assertCommandSuccess(paymentSetDateCommand, model, expectedMsg, expectedModel);
     }
 
-    // Tutee with initalized date to new initialized different date
+    // Tutee with date initialized to new different date
     @Test
-    public void execute_changeInPaymentDate2_success() throws CommandException, ParseException,
-            ScheduleClashException {
+    public void execute_changeInPaymentDate2_success() throws ParseException, ScheduleClashException {
 
         model = new ModelManager(getTypicalTrackO(), new UserPrefs());
         LocalDate newPayByDate2 = ParserUtil.parsePayByDate(NEW_PAYBYDATE_VAL_STUB_2);
@@ -141,14 +133,15 @@ public class PaymentSetDateTest {
         Payment retrievedTuteePayment = retrievedTutee.getPayment();
         String retrievedPaymentVal = retrievedTuteePayment.getValue();
 
+        Model expectedModel = modifyPaymentOfTutee(INDEX_FIRST_TUTEE, retrievedPaymentVal, newPayByDate2, null);
         PaymentSetDateCommand paymentSetDateCommand = new PaymentSetDateCommand(INDEX_FIRST_TUTEE,
                 newPayByDate2);
 
-        paymentSetDateCommand.execute(model);
-        Tutee expectedTutee = PaymentCommand.createEditedPaymentDetailsTutee(retrievedTutee, retrievedPaymentVal,
-                newPayByDate2);
-        Tutee actualTutee = model.getFilteredTuteeList().get(INDEX_FIRST_TUTEE.getZeroBased());
-        assertEquals(expectedTutee.getPayment(), actualTutee.getPayment());
-    }
+        String successMsg = String.format(UPDATE_TUTEE_PAYMENT_SUCCESS, retrievedTutee.getName(),
+                new Payment(retrievedPaymentVal, newPayByDate2));
 
+        CommandResult expectedMsg = new CommandResult(successMsg);
+
+        assertCommandSuccess(paymentSetDateCommand, model, expectedMsg, expectedModel);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/PaymentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PaymentCommandParserTest.java
@@ -80,7 +80,7 @@ public class PaymentCommandParserTest {
     @Test
     public void parse_multipleValues_failure() {
         String failureMsg = String.format(MESSAGE_INVALID_FORMAT,
-                PaymentCommand.MESSAGE_PAYMENT_MANAGEMENT_USAGE);
+                PaymentCommand.MESSAGE_BASIC_USAGE_ALL);
         assertParseFailure(parser, "1" + PAYMENT_LESSON_INDEX_AMY
                 + PAYMENT_AMOUNT_DESC_AMY, failureMsg);
         assertParseFailure(parser, "1" + PAYMENT_DATE_DESC_AMY


### PR DESCRIPTION
Resolved #147, #126

For #147, changed payment message from `Overdue: No (By: XXX)` to `Overdue: No (Next payment date by: XXX)` to make it more explicit that it refers to the next upcoming payment date to be expected.

For #126, adjusted according to what was suggested and changed error message to `tutee index is invalid`.

Added test cases for payment commands as well